### PR TITLE
Add configurable options to the AppEngine object.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -68,6 +68,9 @@ function AppEngine(options) {
   this.httpAgent_ = new http.Agent({
     maxSockets: this.options_.httpAgentMaxSockets
   });
+  if (this.options_.exportPublicFunctions) {
+    this.exportAll_();
+  }
 }
 
 AppEngine.prototype.defaultOptions_ = {
@@ -75,7 +78,8 @@ AppEngine.prototype.defaultOptions_ = {
   logMaxTimestampDeltaMillis: 60000, // 60 seconds
   loggerMaxFiles: 1,
   loggerMaxFileSize: 100 * 1024 * 1024, // 100 MB
-  httpAgentMaxSockets: 100
+  httpAgentMaxSockets: 100,
+  exportPublicFunctions: true
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,18 +43,12 @@ var utils = require('./utils');
 var winston = require('winston');
 
 function AppEngine(options) {
-  this.options_ = options || {};
+  this.options_ = {};
+  goog.object.extend(this.options_, this.defaultOptions_, options || {});
   this.serializer_ = new net.proto2.contrib.WireSerializer();
   this.cache_ = {};
-  this.defaults_ = {
-    logSizeThreshold: 1024 * 1024, // 1 MB
-    logMaxTimestampDeltaMillis: 60000, // 60 seconds
-    loggerMaxFiles: 1,
-    loggerMaxFileSize: 100 * 1024 * 1024, // 100 MB
-    httpAgentMaxSockets: 100
-  };
-  this.logSizeThreshold_ = this.options_.logSizeThreshold || this.defaults_.logSizeThreshold;
-  this.logMaxTimestampDeltaMillis_ = this.options_.logMaxTimestampDeltaMillis || this.defaults_.logMaxTimestampDeltaMillis;
+  this.logSizeThreshold_ = this.options_.logSizeThreshold;
+  this.logMaxTimestampDeltaMillis_ = this.options_.logMaxTimestampDeltaMillis;
   var this_ = this;
   this.logger_ = new (winston.Logger) ({
     transports: [
@@ -66,15 +60,23 @@ function AppEngine(options) {
         stringify: this_.loggingStringify_,
         // TODO(rrch): Enable log rotation once the fluentd config has been
         // updated to accept the kind of filenames winston creates.
-        maxFiles: this_.options_.loggerMaxFiles || this_.defaults_.loggerMaxFiles,
-        maxsize: this_.options_.loggerMaxFileSize || this_.defaults_.loggerMaxFileSize,
+        maxFiles: this_.options_.loggerMaxFiles,
+        maxsize: this_.options_.loggerMaxFileSize
       })
     ]
   });
   this.httpAgent_ = new http.Agent({
-    maxSockets: this.options_.httpAgentMaxSockets || this.defaults_.httpAgentMaxSockets
+    maxSockets: this.options_.httpAgentMaxSockets
   });
 }
+
+AppEngine.prototype.defaultOptions_ = {
+  logSizeThreshold: 1024 * 1024, // 1 MB
+  logMaxTimestampDeltaMillis: 60000, // 60 seconds
+  loggerMaxFiles: 1,
+  loggerMaxFileSize: 100 * 1024 * 1024, // 100 MB
+  httpAgentMaxSockets: 100
+};
 
 /**
  * Export all the public apis.

--- a/lib/index.js
+++ b/lib/index.js
@@ -1006,9 +1006,7 @@ function makeModulesGetHostnameProto(module, version, instance) {
 }
 
 function createAppEngine() {
-  var ae = new AppEngine();
-  ae.exportAll_();
-  return ae;
+  return new AppEngine();
 }
 
 module.exports = createAppEngine();

--- a/lib/index.js
+++ b/lib/index.js
@@ -68,8 +68,8 @@ function AppEngine(options) {
   this.httpAgent_ = new http.Agent({
     maxSockets: this.options_.httpAgentMaxSockets
   });
-  if (this.options_.exportPublicFunctions) {
-    this.exportAll_();
+  if (this.options_.addPublicAPIs) {
+    this.addPublicAPIs_();
   }
 }
 
@@ -79,13 +79,14 @@ AppEngine.prototype.defaultOptions_ = {
   loggerMaxFiles: 1,
   loggerMaxFileSize: 100 * 1024 * 1024, // 100 MB
   httpAgentMaxSockets: 100,
-  exportPublicFunctions: true
+  // Whether to add the surface (public) API layer or not. Only for testing.
+  addPublicAPIs: true
 };
 
 /**
- * Export all the public apis.
+ * Add all the public apis to an AppEngine object.
  */
-AppEngine.prototype.exportAll_ = function() {
+AppEngine.prototype.addPublicAPIs_ = function() {
   this.memcache = {
     get: this.memcacheGet_.bind(this),
     set: this.memcacheSet_.bind(this)
@@ -1005,10 +1006,6 @@ function makeModulesGetHostnameProto(module, version, instance) {
   return getHostnameRequest;
 }
 
-function createAppEngine() {
-  return new AppEngine();
-}
-
-module.exports = createAppEngine();
+module.exports = new AppEngine();
 
 module.exports.AppEngine = AppEngine;

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,11 +42,19 @@ var http = require('http');
 var utils = require('./utils');
 var winston = require('winston');
 
-function AppEngine() {
+function AppEngine(options) {
+  this.options_ = options || {};
   this.serializer_ = new net.proto2.contrib.WireSerializer();
   this.cache_ = {};
-  this.logSizeThreshold_ = 1024 * 1024; // 1 MB
-  this.logMaxTimestampDeltaMillis_ = 60000; // 60 seconds
+  this.defaults_ = {
+    logSizeThreshold: 1024 * 1024, // 1 MB
+    logMaxTimestampDeltaMillis: 60000, // 60 seconds
+    loggerMaxFiles: 1,
+    loggerMaxFileSize: 100 * 1024 * 1024, // 100 MB
+    httpAgentMaxSockets: 100
+  };
+  this.logSizeThreshold_ = this.options_.logSizeThreshold || this.defaults_.logSizeThreshold;
+  this.logMaxTimestampDeltaMillis_ = this.options_.logMaxTimestampDeltaMillis || this.defaults_.logMaxTimestampDeltaMillis;
   var this_ = this;
   this.logger_ = new (winston.Logger) ({
     transports: [
@@ -58,10 +66,13 @@ function AppEngine() {
         stringify: this_.loggingStringify_,
         // TODO(rrch): Enable log rotation once the fluentd config has been
         // updated to accept the kind of filenames winston creates.
-        // maxFiles: 3,
-        maxsize: 100 * 1024 * 1024
+        maxFiles: this_.options_.loggerMaxFiles || this_.defaults_.loggerMaxFiles,
+        maxsize: this_.options_.loggerMaxFileSize || this_.defaults_.loggerMaxFileSize,
       })
     ]
+  });
+  this.httpAgent_ = new http.Agent({
+    maxSockets: this.options_.httpAgentMaxSockets || this.defaults_.httpAgentMaxSockets
   });
 }
 
@@ -248,7 +259,8 @@ AppEngine.prototype.getRemoteApiRequestOptions_ = function(req, data) {
       'Content-Length': data.length,
       'X-Google-RPC-Service-Endpoint': 'app-engine-apis',
       'X-Google-RPC-Service-Method': '/VMRemoteAPI.CallRemoteAPI'
-    }
+    },
+    agent: this.httpAgent_
   };
   if (req.appengine.devappserver) {
     options.hostname = this.getProcessEnv_('API_HOST');
@@ -700,7 +712,8 @@ AppEngine.prototype.authGetServiceAccountToken_ = function(req, callback) {
     method: 'GET',
     headers: {
       'Metadata-Flavor' : 'Google'
-    }
+    },
+    agent: this.httpAgent_
   };
   this.sendHttpRequest_(options, null, function(err, response) {
     if (err) {
@@ -733,7 +746,8 @@ AppEngine.prototype.metadataGetAttribute_ = function(req, name, callback) {
     method: 'GET',
     headers: {
       'Metadata-Flavor' : 'Google'
-    }
+    },
+    agent: this.httpAgent_
   };
   this.sendHttpRequest_(options, null, function(err, response) {
     if (err) {

--- a/test/index.js
+++ b/test/index.js
@@ -75,7 +75,7 @@ describe('appengine', function() {
           loggerMaxFiles: 1,
           loggerMaxFileSize: 100 * 1024 * 1024,
           httpAgentMaxSockets: 100,
-          exportPublicFunctions: true
+          addPublicAPIs: true
         });
       });
 
@@ -100,10 +100,11 @@ describe('appengine', function() {
         assert.ok(!!transport);
         assert.strictEqual(transport.maxFiles, ae.defaultOptions_.loggerMaxFiles);
         assert.strictEqual(transport.maxsize, ae.defaultOptions_.loggerMaxFileSize);
+        assert.strictEqual(ae.options_.addPublicAPIs, true);
       }
 
-      it('calls exportAll_ iff the exportPublicFunctions option is true', function() {
-        var ae = new appengine.AppEngine({exportPublicFunctions: true});
+      it('calls addPublicAPIs_ iff the addPublicAPIs option is true', function() {
+        var ae = new appengine.AppEngine({addPublicAPIs: true});
         assert.strictEqual(typeof(appengine.memcache.get), 'function');
         assert.strictEqual(typeof(appengine.memcache.set), 'function');
         assert.strictEqual(typeof(appengine.taskqueue.add), 'function');
@@ -113,7 +114,7 @@ describe('appengine', function() {
         assert.strictEqual(typeof(appengine.metadata.getAttribute), 'function');
         assert.strictEqual(typeof(appengine.middleware.base), 'function');
 
-        ae = new appengine.AppEngine({exportPublicFunctions: false});
+        ae = new appengine.AppEngine({addPublicAPIs: false});
         assert.strictEqual(ae.memcache, undefined);
         assert.strictEqual(ae.taskqueue, undefined);
         assert.strictEqual(ae.modules, undefined);
@@ -124,9 +125,9 @@ describe('appengine', function() {
       });
     });
 
-    describe('exportAll_', function() {
-      it('should export all public functions', function() {
-        var ae = new appengine.AppEngine({exportPublicFunctions: false});
+    describe('addPublicAPIs_', function() {
+      it('should add all public APIs', function() {
+        var ae = new appengine.AppEngine({addPublicAPIs: false});
         assert.strictEqual(ae.memcache, undefined);
         assert.strictEqual(ae.taskqueue, undefined);
         assert.strictEqual(ae.modules, undefined);
@@ -134,7 +135,7 @@ describe('appengine', function() {
         assert.strictEqual(ae.auth, undefined);
         assert.strictEqual(ae.metadata, undefined);
         assert.strictEqual(ae.middleware, undefined);
-        ae.exportAll_();
+        ae.addPublicAPIs_();
         assert.strictEqual(typeof(appengine.memcache.get), 'function');
         assert.strictEqual(typeof(appengine.memcache.set), 'function');
         assert.strictEqual(typeof(appengine.taskqueue.add), 'function');
@@ -145,75 +146,75 @@ describe('appengine', function() {
         assert.strictEqual(typeof(appengine.middleware.base), 'function');
       });
 
-      it('should export the correct function for memcache.get', function(done) {
-        var ae = new appengine.AppEngine({exportPublicFunctions: false});
+      it('should add the correct function for memcache.get', function(done) {
+        var ae = new appengine.AppEngine({addPublicAPIs: false});
         ae.memcacheGet_ = function() {
           done();
         };
-        ae.exportAll_();
+        ae.addPublicAPIs_();
         ae.memcache.get();
       });
 
-      it('should export the correct function for memcache.set', function(done) {
-        var ae = new appengine.AppEngine({exportPublicFunctions: false});
+      it('should add the correct function for memcache.set', function(done) {
+        var ae = new appengine.AppEngine({addPublicAPIs: false});
         ae.memcacheSet_ = function() {
           done();
         };
-        ae.exportAll_();
+        ae.addPublicAPIs_();
         ae.memcache.set();
       });
 
-      it('should export the correct function for taskqueue.add', function(done) {
-        var ae = new appengine.AppEngine({exportPublicFunctions: false});
+      it('should add the correct function for taskqueue.add', function(done) {
+        var ae = new appengine.AppEngine({addPublicAPIs: false});
         ae.taskQueueAdd_ = function() {
           done();
         };
-        ae.exportAll_();
+        ae.addPublicAPIs_();
         ae.taskqueue.add();
       });
 
-      it('should export the correct function for modules.getHostname', function(done) {
-        var ae = new appengine.AppEngine({exportPublicFunctions: false});
+      it('should add the correct function for modules.getHostname', function(done) {
+        var ae = new appengine.AppEngine({addPublicAPIs: false});
         ae.modulesGetHostname_ = function() {
           done();
         };
-        ae.exportAll_();
+        ae.addPublicAPIs_();
         ae.modules.getHostname();
       });
 
-      it('should export the correct function for system.getBackgroundRequest', function(done) {
-        var ae = new appengine.AppEngine({exportPublicFunctions: false});
+      it('should add the correct function for system.getBackgroundRequest', function(done) {
+        var ae = new appengine.AppEngine({addPublicAPIs: false});
         ae.systemGetBackgroundRequest_ = function() {
           done();
         };
-        ae.exportAll_();
+        ae.addPublicAPIs_();
         ae.system.getBackgroundRequest();
       });
 
-      it('should export the correct function for auth.getServiceAccountToken', function(done) {
-        var ae = new appengine.AppEngine({exportPublicFunctions: false});
+      it('should add the correct function for auth.getServiceAccountToken', function(done) {
+        var ae = new appengine.AppEngine({addPublicAPIs: false});
         ae.authGetServiceAccountToken_ = function() {
           done();
         };
-        ae.exportAll_();
+        ae.addPublicAPIs_();
         ae.auth.getServiceAccountToken();
       });
 
-      it('should export the correct function for metadata.getAttribute', function(done) {
-        var ae = new appengine.AppEngine({exportPublicFunctions: false});
+      it('should add the correct function for metadata.getAttribute', function(done) {
+        var ae = new appengine.AppEngine({addPublicAPIs: false});
         ae.metadataGetAttribute_ = function() {
           done();
         };
-        ae.exportAll_();
+        ae.addPublicAPIs_();
         ae.metadata.getAttribute();
       });
 
-      it('should export the correct function for middleware.base', function(done) {
-        var ae = new appengine.AppEngine({exportPublicFunctions: false});
+      it('should add the correct function for middleware.base', function(done) {
+        var ae = new appengine.AppEngine({addPublicAPIs: false});
         ae.middlewareBase_ = function() {
           done();
         };
-        ae.exportAll_();
+        ae.addPublicAPIs_();
         ae.middleware.base();
       });
     });

--- a/test/index.js
+++ b/test/index.js
@@ -74,7 +74,8 @@ describe('appengine', function() {
           logMaxTimestampDeltaMillis: 60000,
           loggerMaxFiles: 1,
           loggerMaxFileSize: 100 * 1024 * 1024,
-          httpAgentMaxSockets: 100
+          httpAgentMaxSockets: 100,
+          exportPublicFunctions: true
         });
       });
 
@@ -100,11 +101,32 @@ describe('appengine', function() {
         assert.strictEqual(transport.maxFiles, ae.defaultOptions_.loggerMaxFiles);
         assert.strictEqual(transport.maxsize, ae.defaultOptions_.loggerMaxFileSize);
       }
+
+      it('calls exportAll_ iff the exportPublicFunctions option is true', function() {
+        var ae = new appengine.AppEngine({exportPublicFunctions: true});
+        assert.strictEqual(typeof(appengine.memcache.get), 'function');
+        assert.strictEqual(typeof(appengine.memcache.set), 'function');
+        assert.strictEqual(typeof(appengine.taskqueue.add), 'function');
+        assert.strictEqual(typeof(appengine.modules.getHostname), 'function');
+        assert.strictEqual(typeof(appengine.system.getBackgroundRequest), 'function');
+        assert.strictEqual(typeof(appengine.auth.getServiceAccountToken), 'function');
+        assert.strictEqual(typeof(appengine.metadata.getAttribute), 'function');
+        assert.strictEqual(typeof(appengine.middleware.base), 'function');
+
+        ae = new appengine.AppEngine({exportPublicFunctions: false});
+        assert.strictEqual(ae.memcache, undefined);
+        assert.strictEqual(ae.taskqueue, undefined);
+        assert.strictEqual(ae.modules, undefined);
+        assert.strictEqual(ae.system, undefined);
+        assert.strictEqual(ae.auth, undefined);
+        assert.strictEqual(ae.metadata, undefined);
+        assert.strictEqual(ae.middleware, undefined);
+      });
     });
 
     describe('exportAll_', function() {
       it('should export all public functions', function() {
-        var ae = new appengine.AppEngine();
+        var ae = new appengine.AppEngine({exportPublicFunctions: false});
         assert.strictEqual(ae.memcache, undefined);
         assert.strictEqual(ae.taskqueue, undefined);
         assert.strictEqual(ae.modules, undefined);
@@ -124,7 +146,7 @@ describe('appengine', function() {
       });
 
       it('should export the correct function for memcache.get', function(done) {
-        var ae = new appengine.AppEngine();
+        var ae = new appengine.AppEngine({exportPublicFunctions: false});
         ae.memcacheGet_ = function() {
           done();
         };
@@ -133,7 +155,7 @@ describe('appengine', function() {
       });
 
       it('should export the correct function for memcache.set', function(done) {
-        var ae = new appengine.AppEngine();
+        var ae = new appengine.AppEngine({exportPublicFunctions: false});
         ae.memcacheSet_ = function() {
           done();
         };
@@ -142,7 +164,7 @@ describe('appengine', function() {
       });
 
       it('should export the correct function for taskqueue.add', function(done) {
-        var ae = new appengine.AppEngine();
+        var ae = new appengine.AppEngine({exportPublicFunctions: false});
         ae.taskQueueAdd_ = function() {
           done();
         };
@@ -151,7 +173,7 @@ describe('appengine', function() {
       });
 
       it('should export the correct function for modules.getHostname', function(done) {
-        var ae = new appengine.AppEngine();
+        var ae = new appengine.AppEngine({exportPublicFunctions: false});
         ae.modulesGetHostname_ = function() {
           done();
         };
@@ -160,7 +182,7 @@ describe('appengine', function() {
       });
 
       it('should export the correct function for system.getBackgroundRequest', function(done) {
-        var ae = new appengine.AppEngine();
+        var ae = new appengine.AppEngine({exportPublicFunctions: false});
         ae.systemGetBackgroundRequest_ = function() {
           done();
         };
@@ -169,7 +191,7 @@ describe('appengine', function() {
       });
 
       it('should export the correct function for auth.getServiceAccountToken', function(done) {
-        var ae = new appengine.AppEngine();
+        var ae = new appengine.AppEngine({exportPublicFunctions: false});
         ae.authGetServiceAccountToken_ = function() {
           done();
         };
@@ -178,7 +200,7 @@ describe('appengine', function() {
       });
 
       it('should export the correct function for metadata.getAttribute', function(done) {
-        var ae = new appengine.AppEngine();
+        var ae = new appengine.AppEngine({exportPublicFunctions: false});
         ae.metadataGetAttribute_ = function() {
           done();
         };
@@ -187,7 +209,7 @@ describe('appengine', function() {
       });
 
       it('should export the correct function for middleware.base', function(done) {
-        var ae = new appengine.AppEngine();
+        var ae = new appengine.AppEngine({exportPublicFunctions: false});
         ae.middlewareBase_ = function() {
           done();
         };

--- a/test/index.js
+++ b/test/index.js
@@ -69,7 +69,7 @@ describe('appengine', function() {
 
       it('has the expected default values for all options', function() {
         var ae = new appengine.AppEngine();
-        assert.deepEqual(ae.defaults_, {
+        assert.deepEqual(ae.defaultOptions_, {
           logSizeThreshold: 1024 * 1024,
           logMaxTimestampDeltaMillis: 60000,
           loggerMaxFiles: 1,
@@ -92,13 +92,13 @@ describe('appengine', function() {
       });
 
       function verifyAllOptionsHaveDefaultValues(ae) {
-        assert.strictEqual(ae.logSizeThreshold_, ae.defaults_.logSizeThreshold);
-        assert.strictEqual(ae.logMaxTimestampDeltaMillis_, ae.defaults_.logMaxTimestampDeltaMillis);
-        assert.strictEqual(ae.httpAgent_.maxSockets, ae.defaults_.httpAgentMaxSockets);
+        assert.strictEqual(ae.logSizeThreshold_, ae.defaultOptions_.logSizeThreshold);
+        assert.strictEqual(ae.logMaxTimestampDeltaMillis_, ae.defaultOptions_.logMaxTimestampDeltaMillis);
+        assert.strictEqual(ae.httpAgent_.maxSockets, ae.defaultOptions_.httpAgentMaxSockets);
         var transport = ae.logger_.transports.file;
         assert.ok(!!transport);
-        assert.strictEqual(transport.maxFiles, ae.defaults_.loggerMaxFiles);
-        assert.strictEqual(transport.maxsize, ae.defaults_.loggerMaxFileSize);
+        assert.strictEqual(transport.maxFiles, ae.defaultOptions_.loggerMaxFiles);
+        assert.strictEqual(transport.maxsize, ae.defaultOptions_.loggerMaxFileSize);
       }
     });
 


### PR DESCRIPTION
Use an http.Agent for all api and metadata calls.
Default maxSockets for the agent to 100 (https://github.com/GoogleCloudPlatform/appengine-nodejs/issues/34).
